### PR TITLE
123 auto delete on import failure

### DIFF
--- a/src/main/java/de/imi/mopat/controller/QuestionnaireController.java
+++ b/src/main/java/de/imi/mopat/controller/QuestionnaireController.java
@@ -813,6 +813,12 @@ public class QuestionnaireController {
                                                 calendar.getTime()));
                                     }
                                     questionnaireDao.merge(questionnaire);
+
+                                    QuestionnaireVersionGroup questionnaireVersionGroup = questionnaireVersionGroupService.createQuestionnaireGroup(questionnaire.getName());
+                                    questionnaire.setQuestionnaireVersionGroup(questionnaireVersionGroup);
+                                    questionnaireVersionGroup.addQuestionnaire(questionnaire);
+                                    questionnaireVersionGroupService.add(questionnaireVersionGroup);
+
                                     for (ExportTemplate exportTemplate : exportTemplates) {
                                         exportTemplate.setQuestionnaire(questionnaire);
                                         exportTemplate.setName(questionnaire.getName());
@@ -987,6 +993,11 @@ public class QuestionnaireController {
 
                 // Merge questionnaire
                 questionnaireDao.merge(questionnaire);
+
+                QuestionnaireVersionGroup questionnaireVersionGroup = questionnaireVersionGroupService.createQuestionnaireGroup(questionnaire.getName());
+                questionnaire.setQuestionnaireVersionGroup(questionnaireVersionGroup);
+                questionnaireVersionGroup.addQuestionnaire(questionnaire);
+                questionnaireVersionGroupService.add(questionnaireVersionGroup);
 
                 // Merge the export templates
                 for (ExportTemplate exportTemplate : exportTemplates) {

--- a/src/main/java/de/imi/mopat/helper/controller/QuestionnaireVersionGroupService.java
+++ b/src/main/java/de/imi/mopat/helper/controller/QuestionnaireVersionGroupService.java
@@ -195,14 +195,15 @@ public class QuestionnaireVersionGroupService {
             return;
         }
 
+        // Unlink the questionnaire from the group
+        questionnaire.setQuestionnaireVersionGroup(null);
+        questionnaireDao.merge(questionnaire);
+
         if (questionnairesInGroup.isEmpty()){
             //If there would be no questionnaire left, delete the group
             questionnaireVersionGroupDao.remove(questionnaireVersionGroup);
         } else {
-            //Relationship between version group and questionnaire is controlled
-            //by the questionnaire, so it has to be removed there
-            questionnaire.setQuestionnaireVersionGroup(null);
-            questionnaireDao.merge(questionnaire);
+            questionnaireVersionGroupDao.merge(questionnaireVersionGroup);
         }
     }
 }


### PR DESCRIPTION
1. **Fix: Ensure `QuestionnaireVersionGroup` is created for all import types (MoPat, FHIR, ODM)**  
   - Resolved missing group creation for FHIR/ODM imports.  

2. **Fix: Resolve deletion issues caused by bidirectional relationship**  
   - Adjusted deletion logic to unlink questionnaires from groups before checking group state.  
   - Prevented constraint violations during questionnaire deletion.