### PR TITLE
127 clinic rights persistence

### DIFF
--- a/src/main/webapp/WEB-INF/user/rights.html
+++ b/src/main/webapp/WEB-INF/user/rights.html
@@ -302,6 +302,7 @@
 													type="hidden"
 													name="clinicIDs"
 													th:value="${item.id}"
+													disabled="disabled"
 												/>
 												<input
 													type="hidden"


### PR DESCRIPTION
This pull request addresses two improvements:  

1. **HTML Fix for Available Clinics Table:**  
   - Added `disabled="disabled"` attribute to inputs in the "Available Clinics" table in `rights.html`.  
   - Ensures clinics in the "Available Clinics" table are not unintentionally assigned when roles are modified.  
   - The attribute is dynamically updated when clinics are moved between tables.  

2. **Refactored `updateUserClinicRights` Method in `UserService`:**  
   - Renamed variables for clarity:  
     - `assignedClinics` -> `previouslyAssignedClinics`  
     - `currentClinics` -> `newlyAssignedClinics`  
   - Introduced `clinicsToAdd` and `clinicsToRemove` for clearer logic.  
   - Improved readability by explicitly separating the logic for adding and removing clinic rights.  