### PR TITLE
Fix: Correct button display after validation errors

### DIFF
--- a/src/main/webapp/WEB-INF/questionnaire/edit.html
+++ b/src/main/webapp/WEB-INF/questionnaire/edit.html
@@ -165,7 +165,7 @@
 					<div class="alert alert-info" role="alert" th:text="${infoMessage}"></div>
 				</th:block>
 
-				<th:block th:if="${canEdit}">
+				<th:block th:if="${isEditableState}">
 					<button
 							type="submit"
 							class="btn btn-primary"
@@ -183,7 +183,7 @@
 							th:text="${messages.get(#locale, 'questionnaire.button.saveAndEdit', 'Save and edit questions')}"
 					></button>
 				</th:block>
-				<th:block th:unless="${canEdit}">
+				<th:block th:unless="${isEditableState}">
 					<button
 							type="submit"
 							class="btn btn-primary"


### PR DESCRIPTION
**Description:**  
This fix ensures that the correct buttons are displayed after validation errors during questionnaire editing by guaranteeing the `isEditableState` field is always set in the model.  

**Changes:**
- Renamed `canEdit` to `isEditableState` for improved clarity.  
- Updated `edit.html` to use `isEditableState` for button display logic.  
- Renamed `handleValidationErrors` to `fillModelForValidationErrors` and refactored it to ensure `isEditableState` is added to the model even after validation errors.  

**Expected Behavior:**  
- Save buttons are displayed if the questionnaire is editable.  
- Duplicate buttons appear only when editing is not allowed, even after a validation error.  