### PR TITLE
Removed direct-translation expression from bundle view

### DIFF
--- a/src/main/webapp/WEB-INF/mobile/survey/bundles.html
+++ b/src/main/webapp/WEB-INF/mobile/survey/bundles.html
@@ -3,7 +3,7 @@
 */-->
 <th:block
 	layout:decorate="~{layout/mobile}"
-	th:with="contenttype='content', title=__${messages.get(#locale, 'survey.title.selectBundle', 'Select bundle')}__"
+	th:with="contenttype='content', title=${messages.get(#locale, 'survey.title.selectBundle', 'Select bundle')}"
 >
 	<th:block layout:fragment="content">
 		<form


### PR DESCRIPTION
Adjusted the template, so that the view works for other locales as well. 