### PR TITLE
Fix: Add clinic list to model on validation error

### DIFF
--- a/src/main/java/de/imi/mopat/controller/EncounterController.java
+++ b/src/main/java/de/imi/mopat/controller/EncounterController.java
@@ -362,6 +362,7 @@ public class EncounterController {
         encounterScheduledDTOValidator.validate(encounterScheduledDTO, result);
 
         if (result.hasErrors()) {
+            addClinicInfoToModel(model, getCurrentUser());
             List<Bundle> bundles = bundleDao.getAllElements();
             List<BundleDTO> bundleDTOs = new ArrayList<>();
             for (Bundle bundle : bundles) {


### PR DESCRIPTION
**Pull Request Description:**

Fixes #158: Ensures the clinic list is repopulated in the model after validation errors by calling `addClinicInfoToModel`.