### PR TITLE
173 moderator and editor can release a bundle during the creation

### DIFF
--- a/src/main/java/de/imi/mopat/controller/BundleController.java
+++ b/src/main/java/de/imi/mopat/controller/BundleController.java
@@ -71,35 +71,6 @@ public class BundleController {
     private BundleService bundleService;
     @Autowired
     private ClinicService clinicService;
-    @Autowired
-    private BundleDTOMapper bundleDTOMapper;
-
-    /**
-     * @param id for bundle
-     * @return resulting bundle for id
-     */
-    public BundleDTO getBundleDTO(final Long id) {
-        BundleDTO result;
-        BundleDTO bundleDTO;
-        if (id == null || id <= 0) {
-            result = new BundleDTO();
-        } else {
-            Bundle bundle = bundleDao.getElementById(id);
-            if (bundle == null) {
-                result = new BundleDTO();
-            } else {
-                bundleDTO = bundleDTOMapper.apply(true,bundle);
-                for (BundleQuestionnaireDTO bundleQuestionnaireDTO
-                        : bundleDTO.getBundleQuestionnaireDTOs()) {
-                    bundleQuestionnaireDTO.getQuestionnaireDTO()
-                                          .setHasScores(scoreDao.hasScore(questionnaireDao.getElementById(bundleQuestionnaireDTO.getQuestionnaireDTO()
-                                                                                                                                .getId())));
-                }
-                result = bundleDTO;
-            }
-        }
-        return result;
-    }
 
     /**
      * Controls the HTTP GET requests for the URL <i>/bundle/list</i>. Shows the list of bundles.
@@ -137,7 +108,7 @@ public class BundleController {
     @PreAuthorize("hasRole('ROLE_EDITOR')")
     public String fillBundle(@RequestParam(value = "id", required = false) final Long bundleId,
         final Model model) {
-        BundleDTO bundleDTO = getBundleDTO(bundleId);
+        BundleDTO bundleDTO = bundleService.getBundleDTO(bundleId);
         model.addAttribute("bundleDTO", bundleDTO);
         model.addAttribute("availableLocales", LocaleHelper.getAvailableLocales());
         model.addAttribute("availableQuestionnaireDTOs", bundleService.getAvailableQuestionnaires(bundleId));

--- a/src/main/java/de/imi/mopat/controller/BundleController.java
+++ b/src/main/java/de/imi/mopat/controller/BundleController.java
@@ -31,6 +31,7 @@ import de.imi.mopat.model.dto.BundleQuestionnaireDTO;
 import de.imi.mopat.model.dto.QuestionnaireDTO;
 import de.imi.mopat.model.user.AclObjectIdentity;
 import de.imi.mopat.model.user.User;
+import de.imi.mopat.model.user.UserRole;
 import de.imi.mopat.validator.BundleDTOValidator;
 
 import java.util.ArrayList;
@@ -219,6 +220,10 @@ public class BundleController {
         if (bundleDTO.getId() != null && !bundleDao.getElementById(bundleDTO.getId())
             .isModifiable()) {
             return "redirect:/bundle/fill?id=" + bundleDTO.getId();
+        }
+
+        if (!authService.hasExactRole(UserRole.ROLE_ADMIN)){
+            bundleDTO.setIsPublished(false);
         }
 
         // Check if one of the welcome texts has only one newline and

--- a/src/main/java/de/imi/mopat/controller/BundleController.java
+++ b/src/main/java/de/imi/mopat/controller/BundleController.java
@@ -224,25 +224,7 @@ public class BundleController {
             bundleDTO.setIsPublished(false);
         }
 
-        // Check if one of the welcome texts has only one newline and
-        // change it to an empty string
-        SortedMap<String, String> tempLocalizedWelcomeText = bundleDTO.getLocalizedWelcomeText();
-        for (SortedMap.Entry entry : tempLocalizedWelcomeText.entrySet()) {
-            if (entry.getValue().equals("<p><br></p>") || entry.getValue().equals("<br>")) {
-                entry.setValue("");
-            }
-        }
-        bundleDTO.setLocalizedWelcomeText(tempLocalizedWelcomeText);
-
-        // Check if one of the final texts has only one newline and
-        // change it to an empty string
-        SortedMap<String, String> tempLocalizedFinalText = bundleDTO.getLocalizedFinalText();
-        for (SortedMap.Entry entry : tempLocalizedFinalText.entrySet()) {
-            if (entry.getValue().equals("<p><br></p>") || entry.getValue().equals("<br>")) {
-                entry.setValue("");
-            }
-        }
-        bundleDTO.setLocalizedFinalText(tempLocalizedFinalText);
+        bundleService.prepareBundleForEdit(bundleDTO);
 
         List<QuestionnaireDTO> availableQuestionnaireDTOs = getAvailableQuestionnaires(null);
         List<BundleQuestionnaireDTO> assignedBundleQuestionnaireDTOs = new ArrayList<>(
@@ -253,14 +235,7 @@ public class BundleController {
         // bundleDTO are detained
         for (QuestionnaireDTO questionnaireDTO : new ArrayList<>(availableQuestionnaireDTOs)) {
             for (BundleQuestionnaireDTO bundleQuestionnaireDTO : assignedBundleQuestionnaireDTOs) {
-                if (bundleQuestionnaireDTO.getQuestionnaireDTO() == null
-                    || bundleQuestionnaireDTO.getQuestionnaireDTO().getId() == null) {
-                    // Delete empty entries
-                    bundleDTO.getBundleQuestionnaireDTOs().remove(bundleQuestionnaireDTO);
-                    // If this available questionnaire is in the assigned
-                    // questionnaire list as well,
-                    // remove it from the available list
-                } else if (questionnaireDTO.getId().longValue()
+                if (questionnaireDTO.getId().longValue()
                     == bundleQuestionnaireDTO.getQuestionnaireDTO().getId().longValue()) {
                     // Remove this questionnaire from the list with available
                     // questionnaires

--- a/src/main/java/de/imi/mopat/controller/BundleController.java
+++ b/src/main/java/de/imi/mopat/controller/BundleController.java
@@ -270,6 +270,8 @@ public class BundleController {
                     // Set the export templates to the assigned questionnaire
                     bundleQuestionnaireDTO.getQuestionnaireDTO()
                         .setExportTemplates(questionnaireDTO.getExportTemplates());
+                    bundleQuestionnaireDTO.getQuestionnaireDTO()
+                            .setQuestionnaireGroupDTO(questionnaireDTO.getQuestionnaireGroupDTO());
                 }
             }
         }

--- a/src/main/java/de/imi/mopat/controller/BundleController.java
+++ b/src/main/java/de/imi/mopat/controller/BundleController.java
@@ -245,6 +245,8 @@ public class BundleController {
                         .setExportTemplates(questionnaireDTO.getExportTemplates());
                     bundleQuestionnaireDTO.getQuestionnaireDTO()
                             .setQuestionnaireGroupDTO(questionnaireDTO.getQuestionnaireGroupDTO());
+                    bundleQuestionnaireDTO.getQuestionnaireDTO()
+                            .setHasScores(questionnaireDTO.getHasScores());
                 }
             }
         }

--- a/src/main/java/de/imi/mopat/controller/BundleController.java
+++ b/src/main/java/de/imi/mopat/controller/BundleController.java
@@ -195,35 +195,7 @@ public class BundleController {
         bundleService.prepareBundleForEdit(bundleDTO);
 
         List<QuestionnaireDTO> availableQuestionnaireDTOs = bundleService.getAvailableQuestionnaires(null);
-        List<BundleQuestionnaireDTO> assignedBundleQuestionnaireDTOs = new ArrayList<>(
-            bundleDTO.getBundleQuestionnaireDTOs());
-        List<QuestionnaireDTO> questionnaireDTOsToDelete = new ArrayList<>();
-
-        //make sure the changes in the bundleQuestionnaireDTO list of
-        // bundleDTO are detained
-        for (QuestionnaireDTO questionnaireDTO : new ArrayList<>(availableQuestionnaireDTOs)) {
-            for (BundleQuestionnaireDTO bundleQuestionnaireDTO : assignedBundleQuestionnaireDTOs) {
-                if (questionnaireDTO.getId().longValue()
-                    == bundleQuestionnaireDTO.getQuestionnaireDTO().getId().longValue()) {
-                    // Remove this questionnaire from the list with available
-                    // questionnaires
-                    questionnaireDTOsToDelete.add(questionnaireDTO);
-                    // Set the export templates to the assigned questionnaire
-                    bundleQuestionnaireDTO.getQuestionnaireDTO()
-                        .setExportTemplates(questionnaireDTO.getExportTemplates());
-                    bundleQuestionnaireDTO.getQuestionnaireDTO()
-                            .setQuestionnaireGroupDTO(questionnaireDTO.getQuestionnaireGroupDTO());
-                    bundleQuestionnaireDTO.getQuestionnaireDTO()
-                            .setHasScores(questionnaireDTO.getHasScores());
-                }
-            }
-        }
-        availableQuestionnaireDTOs.removeAll(questionnaireDTOsToDelete);
-
-        // Sort assigned bundle questionnaires by position
-        Collections.sort(bundleDTO.getBundleQuestionnaireDTOs(),
-            (BundleQuestionnaireDTO o1, BundleQuestionnaireDTO o2) -> o1.getPosition()
-                .compareTo(o2.getPosition()));
+        bundleService.syncAssignedAndAvailableQuestionnaires(bundleDTO.getBundleQuestionnaireDTOs(), availableQuestionnaireDTOs);
 
         // Validate the bundle object
         bundleDTOValidator.validate(bundleDTO, result);

--- a/src/main/java/de/imi/mopat/controller/BundleController.java
+++ b/src/main/java/de/imi/mopat/controller/BundleController.java
@@ -216,9 +216,7 @@ public class BundleController {
             return "redirect:/bundle/list";
         }
 
-        // If the bundle has any incomplete encounters, it may not be edited
-        if (bundleDTO.getId() != null && !bundleDao.getElementById(bundleDTO.getId())
-            .isModifiable()) {
+        if (!bundleService.isBundleModifiable(bundleDTO)) {
             return "redirect:/bundle/fill?id=" + bundleDTO.getId();
         }
 

--- a/src/main/java/de/imi/mopat/controller/BundleController.java
+++ b/src/main/java/de/imi/mopat/controller/BundleController.java
@@ -121,38 +121,6 @@ public class BundleController {
     }
 
     /**
-     * @param id is id of the {@link Bundle Bundle} object
-     * @return Returns all {@link Questionnaire Questionnaire} objects that are not already present
-     * in the bundle with the given id.
-     */
-    private List<QuestionnaireDTO> getAvailableQuestionnaires(final Long bundleId) {
-        // Fetch questionnaires not linked with the given bundle
-        List<Questionnaire> availableQuestionnaires = bundleDao.getAvailableQuestionnairesForBundle(bundleId);
-
-        // Collect IDs for fetching scores
-        Set<Long> questionnaireIds = availableQuestionnaires.stream().map(Questionnaire::getId).collect(Collectors.toSet());
-        Set<Long> questionnairesWithScores = new HashSet<>();
-        if (!questionnaireIds.isEmpty()) {
-            questionnairesWithScores.addAll(
-                scoreDao.findQuestionnairesWithScores(
-                    new ArrayList<>(questionnaireIds)
-                )
-            );
-        }
-
-        // Map to DTO and sort
-        return availableQuestionnaires.stream()
-            .filter(q -> !q.getQuestions().isEmpty())
-            .map(q -> {
-                QuestionnaireDTO dto = questionnaireDTOMapper.apply(q);
-                dto.setHasScores(questionnairesWithScores.contains(q.getId()));
-                return dto;
-            })
-            .sorted(Comparator.comparing(QuestionnaireDTO::getName, String.CASE_INSENSITIVE_ORDER))
-            .collect(Collectors.toList());
-    }
-
-    /**
      * Controls the HTTP GET requests for the URL <i>/bundle/list</i>. Shows the list of bundles.
      *
      * @param model The model, which holds the information for the view.
@@ -226,7 +194,7 @@ public class BundleController {
 
         bundleService.prepareBundleForEdit(bundleDTO);
 
-        List<QuestionnaireDTO> availableQuestionnaireDTOs = getAvailableQuestionnaires(null);
+        List<QuestionnaireDTO> availableQuestionnaireDTOs = bundleService.getAvailableQuestionnaires(null);
         List<BundleQuestionnaireDTO> assignedBundleQuestionnaireDTOs = new ArrayList<>(
             bundleDTO.getBundleQuestionnaireDTOs());
         List<QuestionnaireDTO> questionnaireDTOsToDelete = new ArrayList<>();

--- a/src/main/java/de/imi/mopat/helper/controller/BundleService.java
+++ b/src/main/java/de/imi/mopat/helper/controller/BundleService.java
@@ -7,6 +7,7 @@ import de.imi.mopat.dao.BundleQuestionnaireDao;
 import de.imi.mopat.dao.ExportTemplateDao;
 import de.imi.mopat.dao.QuestionnaireDao;
 import de.imi.mopat.dao.ScoreDao;
+import de.imi.mopat.helper.model.BundleDTOMapper;
 import de.imi.mopat.helper.model.QuestionnaireDTOMapper;
 import de.imi.mopat.model.Bundle;
 import de.imi.mopat.model.BundleQuestionnaire;
@@ -52,6 +53,37 @@ public class BundleService {
     private AclClassDao aclClassDao;
     @Autowired
     private AclObjectIdentityDao aclObjectIdentityDao;
+    @Autowired
+    private BundleDTOMapper bundleDTOMapper;
+
+    /**
+     * Retrieves a BundleDTO for the given bundle ID.
+     *
+     * @param id The ID of the bundle.
+     * @return The corresponding BundleDTO or a new instance if the bundle is not found.
+     */
+    public BundleDTO getBundleDTO(final Long id) {
+        if (id == null || id <= 0) {
+            return new BundleDTO();
+        }
+
+        Bundle bundle = bundleDao.getElementById(id);
+        if (bundle == null) {
+            return new BundleDTO();
+        }
+
+        BundleDTO bundleDTO = bundleDTOMapper.apply(true, bundle);
+
+        bundleDTO.getBundleQuestionnaireDTOs().forEach(bundleQuestionnaireDTO -> {
+            QuestionnaireDTO questionnaireDTO = bundleQuestionnaireDTO.getQuestionnaireDTO();
+            if (questionnaireDTO != null && questionnaireDTO.getId() != null) {
+                questionnaireDTO.setHasScores(scoreDao.hasScore(questionnaireDao.getElementById(questionnaireDTO.getId())));
+            }
+        });
+
+        return bundleDTO;
+    }
+
 
     /**
      * Retrieves all available {@link QuestionnaireDTO} objects that are not currently assigned

--- a/src/main/java/de/imi/mopat/helper/controller/BundleService.java
+++ b/src/main/java/de/imi/mopat/helper/controller/BundleService.java
@@ -74,7 +74,7 @@ public class BundleService {
                         Comparator.comparing(QuestionnaireDTO::getQuestionnaireVersionGroupName, String::compareToIgnoreCase)
                                 .thenComparing(QuestionnaireDTO::getQuestionnaireVersionGroupId)
                                 .thenComparing(QuestionnaireDTO::getVersion))
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/de/imi/mopat/helper/controller/BundleService.java
+++ b/src/main/java/de/imi/mopat/helper/controller/BundleService.java
@@ -213,32 +213,18 @@ public class BundleService {
             bundleDTO.setIsPublished(false);
         }
         // Set property of the Bundle to current user
-        User principal = authService.getAuthenticatedUser();
+        User currentUser = authService.getAuthenticatedUser();
 
-        Bundle bundle;
-        if (bundleDTO.getId() != null) {
-            bundle = bundleDao.getElementById(bundleDTO.getId());
-            bundle.setName(bundleDTO.getName());
-            bundle.setChangedBy(principal.getId());
-            bundle.setDescription(bundleDTO.getDescription());
-            bundle.setIsPublished(bundleDTO.getIsPublished());
-            bundle.setShowProgressPerBundle(bundleDTO.getShowProgressPerBundle());
-            bundle.setDeactivateProgressAndNameDuringSurvey(
-                    bundleDTO.getdeactivateProgressAndNameDuringSurvey());
-        } else {
-            bundle = new Bundle(bundleDTO.getName(), bundleDTO.getDescription(), principal.getId(),
-                    bundleDTO.getIsPublished(), bundleDTO.getShowProgressPerBundle(),
-                    bundleDTO.getdeactivateProgressAndNameDuringSurvey());
-        }
-        bundle.setLocalizedWelcomeText(bundleDTO.getLocalizedWelcomeText());
-        bundle.setLocalizedFinalText(bundleDTO.getLocalizedFinalText());
+        Bundle bundle = (bundleDTO.getId() != null)
+                ? bundleDao.getElementById(bundleDTO.getId())
+                : new Bundle();
+
+        updateBundleProperties(bundle, bundleDTO, currentUser);
 
         if (bundle.getId() == null) { // the bundle is completely new, thus
             // no removal of BundleQuestionnaire objects necessary and in the
             // end persist (not merge)
             bundleDao.merge(bundle);
-            // Get the current user, which is the owner of the bundle
-            User currentUser = authService.getAuthenticatedUser();
             // Create a new ACLObjectIdentity for the bundle and save it
             AclObjectIdentity bundleObjectIdentity = new AclObjectIdentity(bundle.getId(),
                     Boolean.TRUE, aclClassDao.getElementByClass(Bundle.class.getName()), currentUser,
@@ -306,5 +292,16 @@ public class BundleService {
             bundle.setIsPublished(Boolean.FALSE);
         }
         bundleDao.merge(bundle);
+    }
+
+    private void updateBundleProperties(Bundle bundle, BundleDTO bundleDTO, User principal) {
+        bundle.setName(bundleDTO.getName());
+        bundle.setChangedBy(principal.getId());
+        bundle.setDescription(bundleDTO.getDescription());
+        bundle.setShowProgressPerBundle(bundleDTO.getShowProgressPerBundle());
+        bundle.setDeactivateProgressAndNameDuringSurvey(bundleDTO.getdeactivateProgressAndNameDuringSurvey());
+        bundle.setLocalizedWelcomeText(bundleDTO.getLocalizedWelcomeText());
+        bundle.setLocalizedFinalText(bundleDTO.getLocalizedFinalText());
+        bundle.setIsPublished(bundleDTO.getIsPublished());
     }
 }

--- a/src/main/java/de/imi/mopat/helper/controller/BundleService.java
+++ b/src/main/java/de/imi/mopat/helper/controller/BundleService.java
@@ -86,15 +86,11 @@ public class BundleService {
 
 
     /**
-     * Retrieves all available {@link QuestionnaireDTO} objects that are not currently assigned
-     * to the {@link Bundle} with the given ID. This method filters out any questionnaires that
-     * have no associated questions and sorts the results first by group name, then by group ID,
-     * and finally by version.
+     * Retrieves all questionnaires that are not assigned to the given bundle.
+     * The list is sorted by group name, group ID, and version.
      *
-     * @param bundleId The ID of the {@link Bundle} from which unassigned questionnaires should be retrieved.
-     * @return A sorted list of {@link QuestionnaireDTO} objects that are not assigned to the specified bundle
-     *         and contain at least one question. If the bundle ID is null or not found, all available questionnaires
-     *         are returned.
+     * @param bundleId The ID of the bundle.
+     * @return A sorted list of unassigned questionnaires.
      */
     public List<QuestionnaireDTO> getAvailableQuestionnaires(final Long bundleId) {
         Optional<Bundle> bundle = findBundleById(bundleId);
@@ -175,6 +171,12 @@ public class BundleService {
         return bundleDTO.getId() == null || bundleDao.getElementById(bundleDTO.getId()).isModifiable();
     }
 
+    /**
+     * Prepares a bundle for editing by cleaning text fields and ensuring
+     * that non-admin users cannot publish the bundle.
+     *
+     * @param bundleDTO The bundle to prepare.
+     */
     public void prepareBundleForEdit(BundleDTO bundleDTO) {
         cleanUpTextFields(bundleDTO);
 
@@ -201,8 +203,15 @@ public class BundleService {
         );
     }
 
+    /**
+     * Synchronizes assigned and available questionnaires.
+     * Ensures that assigned questionnaires are removed from the available list
+     * and updates missing data (ExportTemplates, QuestionnaireGroup, Scores) for assigned questionnaires.
+     *
+     * @param bundleQuestionnaireDTOS The list of assigned questionnaires.
+     * @param availableQuestionnaireDTOs The list of available questionnaires.
+     */
     public void syncAssignedAndAvailableQuestionnaires(List<BundleQuestionnaireDTO> bundleQuestionnaireDTOS, List<QuestionnaireDTO> availableQuestionnaireDTOs) {
-        // IDs der bereits zugewiesenen Fragebögen sammeln
         Set<Long> assignedIds = bundleQuestionnaireDTOS.stream()
                 .map(BundleQuestionnaireDTO::getQuestionnaireDTO)
                 .filter(Objects::nonNull)
@@ -234,6 +243,12 @@ public class BundleService {
         });
     }
 
+    /**
+     * Saves or updates the given bundle.
+     * If the bundle does not exist, it is created. Otherwise, it is updated.
+     *
+     * @param bundleDTO The bundle data.
+     */
     public void saveOrUpdateBundle(BundleDTO bundleDTO) {
         User currentUser = authService.getAuthenticatedUser();
 

--- a/src/main/java/de/imi/mopat/helper/controller/BundleService.java
+++ b/src/main/java/de/imi/mopat/helper/controller/BundleService.java
@@ -8,6 +8,7 @@ import de.imi.mopat.helper.model.QuestionnaireDTOMapper;
 import de.imi.mopat.model.Bundle;
 import de.imi.mopat.model.BundleQuestionnaire;
 import de.imi.mopat.model.Questionnaire;
+import de.imi.mopat.model.dto.BundleDTO;
 import de.imi.mopat.model.dto.QuestionnaireDTO;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -125,5 +126,7 @@ public class BundleService {
         return resultSet;
     }
 
-
+    public boolean isBundleModifiable(BundleDTO bundleDTO) {
+        return bundleDTO.getId() == null || bundleDao.getElementById(bundleDTO.getId()).isModifiable();
+    }
 }

--- a/src/main/webapp/WEB-INF/bundle/edit.html
+++ b/src/main/webapp/WEB-INF/bundle/edit.html
@@ -134,7 +134,7 @@
 					>
 					</checkbox>
 				</div>
-				<div class="form-group">
+				<div class="form-group" sec:authorize="hasRole('ROLE_ADMIN')">
 					<checkbox
 						layout:replace="~{fragments/forms :: checkbox(
                         path='isPublished',


### PR DESCRIPTION
Restricted `isPublished` to admins, ensured validation error persistence, and refactored bundle-related logic into `BundleService`.

**Key Changes:**  
- Restricted `isPublished` to admins in the backend and frontend.
- Ensured `hasScores` and `QuestionnaireGroupDTO` persist after validation errors.  
- Moved `getBundleDTO`, `saveOrUpdateBundle`, and related logic to `BundleService`.  
- Extracted methods for questionnaire persistence, ACL creation, and property updates.