### PR TITLE
Upgrade to JDK 21

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
 

--- a/pom.xml
+++ b/pom.xml
@@ -1036,7 +1036,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <release>17</release>
+                    <release>21</release>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                     </compilerArgs>


### PR DESCRIPTION
Resolves #253.

Upgrades the build from Java 17 to Java 21:
- `maven-compiler-plugin` `release` 17 → 21
- `pr-checks` workflow `java-version` 17 → 21

Verified locally: the full `mvn test` suite is green under Temurin 21 — **1025 tests run, 0 failures, 0 errors, 10 skipped**, identical to the Java-17 baseline (no test lost), run against a MariaDB instance mirroring the CI `mariadb` service and schema (`db/installationInitTest.sql`). `maven-compiler-plugin` 3.11.0 already supports release 21, so no plugin bump was needed.

*Prepared with the open-source [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.*
